### PR TITLE
Updated Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 CC=g++
 TARGET=ipxnet
 SRCFILES=main.cpp ipxserver.cpp
-LIBS=-lSDL_net
+LIBS=-lSDL_net -lSDL
 
 all: $(TARGET)
 


### PR DESCRIPTION
Building with libSDL 1.2, had undefined reference to symbol 'SDL_GetError' without linking in SDL itself.